### PR TITLE
Fix SetPrivate and validation

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -181,7 +181,7 @@ func ValidateSignatureValues(v byte, r, s *big.Int, homestead bool) bool {
 	if s.Cmp(secp256k1.N) >= 0 {
 		return false
 	}
-	if r.Cmp(secp256k1.N) < 0 && (vint == 27 || vint == 28) {
+	if r.Cmp(secp256k1.N) < 0 && (vint == 27 || vint == 28 || vint == 37 || vint == 38) {
 		return true
 	} else {
 		return false


### PR DESCRIPTION
* Builds on the fix in c828292fa2c009e2865b1f0d521a080499a234d8;
* SetPrivate() must be called after the tx has been signed and just before inserting into txpool.
* Added 37 & 38 as valid V values in validation routine

V value looks correct now however I'm now seeing the txn get stuck in `pending` state in the txpool. Other txns added (on the same node) after that one also get stuck.