### PR TITLE
quorum: retrieve nonce from txpool instead of pending state

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -129,6 +129,17 @@ func (pool *TxPool) eventLoop() {
 	}
 }
 
+// Nonce returns the nonce for the given addr from the pending state.
+// Can only be used for local transactions.
+func (pool *TxPool) Nonce(addr common.Address) uint64 {
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
+	if pool.pendingState == nil {
+		pool.resetState()
+	}
+	return pool.pendingState.GetNonce(addr)
+}
+
 func (pool *TxPool) resetState() {
 	currentState, _, err := pool.currentState()
 	if err != nil {


### PR DESCRIPTION
The voter uses abigen generated sources. The default behavior is to fetch the node from the pending state. Since transactions that are included in the transaction pool are broadcasted through the eventing system and applied later to the pending this can cause nonce issues when the nonce is request for the next transaction while the previous transaction was not yet processed to the pending state. This PR will retrieve the nonce from the txpool.