### PR TITLE
p2p/enode, p2p/discv5: fix URL parsing test for go 1.11.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 
 language: go
 go_import_path: github.com/ethereum/go-ethereum
-go: 1.11.12
+go: 1.11.x
 sudo: true
 branches:
   only:

--- a/p2p/discv5/node_test.go
+++ b/p2p/discv5/node_test.go
@@ -152,7 +152,7 @@ func TestParseNode(t *testing.T) {
 			if err == nil {
 				t.Errorf("test %q:\n  got nil error, expected %#q", test.rawurl, test.wantError)
 				continue
-			} else if err.Error() != test.wantError {
+			} else if !strings.Contains(err.Error(), test.wantError) {
 				t.Errorf("test %q:\n  got error %#q, expected %#q", test.rawurl, err.Error(), test.wantError)
 				continue
 			}

--- a/p2p/enode/urlv4_test.go
+++ b/p2p/enode/urlv4_test.go
@@ -139,7 +139,7 @@ func TestParseNode(t *testing.T) {
 			if err == nil {
 				t.Errorf("test %q:\n  got nil error, expected %#q", test.rawurl, test.wantError)
 				continue
-			} else if err.Error() != test.wantError {
+			} else if !strings.Contains(err.Error(), test.wantError) {
 				t.Errorf("test %q:\n  got error %#q, expected %#q", test.rawurl, err.Error(), test.wantError)
 				continue
 			}


### PR DESCRIPTION
- Revert https://github.com/jpmorganchase/quorum/pull/803 to use 1.11.x in Travis
- Cherry-pick https://github.com/ethereum/go-ethereum/pull/19963 to fix failing tests