### PR TITLE
fix typos 

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Please see the [Developers' Guide](https://geth.ethereum.org/docs/developers/dev
 for more details on configuring your environment, managing project dependencies
 and testing procedures.
 
-## Issue reproductibility
+## Issue reproducibility
 
 Before you create an issue, please try to reproduce it with [quorum quick dev start framework](https://github.com/ConsenSys/quorum-dev-quickstart) with the latest release.
 Many issues have been creating under an environment we are not able to reproduce quickly.

--- a/accounts/scwallet/README.md
+++ b/accounts/scwallet/README.md
@@ -8,7 +8,7 @@
 
 ## Preparing the smartcard
 
-  **WARNING: FOILLOWING THESE INSTRUCTIONS WILL DESTROY THE MASTER KEY ON YOUR CARD. ONLY PROCEED IF NO FUNDS ARE ASSOCIATED WITH THESE ACCOUNTS**
+  **WARNING: FOLLOWING THESE INSTRUCTIONS WILL DESTROY THE MASTER KEY ON YOUR CARD. ONLY PROCEED IF NO FUNDS ARE ASSOCIATED WITH THESE ACCOUNTS**
 
   You can use status' [keycard-cli](https://github.com/status-im/keycard-cli) and you should get _at least_ version 2.1.1 of their [smartcard application](https://github.com/status-im/status-keycard/releases/download/2.2.1/keycard_v2.2.1.cap)
 

--- a/cmd/clef/rules.md
+++ b/cmd/clef/rules.md
@@ -81,7 +81,7 @@ Additionally, a few more have been added
 
 Some security precautions can be made, such as:
 
-* Never load `ruleset.js` unless the file is `readonly` (`r-??-??-?`). If the user wishes to modify the ruleset, he must make it writeable and then set back to readonly.
+* Never load `ruleset.js` unless the file is `readonly` (`r-??-??-?`). If the user wishes to modify the ruleset, he must make it writable and then set back to readonly.
   * This is to prevent attacks where files are dropped on the users disk.
 * Since we're going to have to have some form of secure storage (not defined in this section), we could also store the `sha3` of the `ruleset.js` file in there.
   * If the user wishes to modify the ruleset, he'd then have to perform e.g. `signer --attest /path/to/ruleset --credential <creds>`

--- a/cmd/evm/README.md
+++ b/cmd/evm/README.md
@@ -6,7 +6,7 @@ which can
 1. Take a prestate, including
   - Accounts,
   - Block context information,
-  - Previous blockshashes (*optional)
+  - Previous blockhashes (*optional)
 2. Apply a set of transactions,
 3. Apply a mining-reward (*optional),
 4. And generate a post-state, including
@@ -16,7 +16,7 @@ which can
 
 ## Specification
 
-The idea is to specify the behaviour of this binary very _strict_, so that other
+The idea is to specify the behavior of this binary very _strict_, so that other
 node implementors can build replicas based on their own state-machines, and the
 state generators can swap between a `geth`-based implementation and a `parityvm`-based
 implementation.

--- a/cmd/faucet/README.md
+++ b/cmd/faucet/README.md
@@ -10,7 +10,7 @@ The `faucet` is a single binary app (everything included) with all configuration
 
 First thing's first, the `faucet` needs to connect to an Ethereum network, for which it needs the necessary genesis and network infos. Each of the following flags must be set:
 
-- `--genesis` is a path to a file containin the network `genesis.json`
+- `--genesis` is a path to a file containing the network `genesis.json`
 - `--network` is the devp2p network id used during connection
 - `--bootnodes` is a list of `enode://` ids to join the network through
 

--- a/tests/fuzzers/README.md
+++ b/tests/fuzzers/README.md
@@ -32,7 +32,7 @@ go-fuzz -bin ./rlp/rlp-fuzz.zip
 ### Notes
 
 Once a 'crasher' is found, the fuzzer tries to avoid reporting the same vector twice, so stores the fault in the `suppressions` folder. Thus, if you 
-e.g. make changes to fix a bug, you should _remove_ all data from the `suppressions`-folder, to verify that the issue is indeed resolved. 
+e.g. make changes to fix a bug, you should _remove_ all data from the `suppressions`folder, to verify that the issue is indeed resolved. 
 
 Also, if you have only one and the same exit-point for multiple different types of test, the suppression can make the fuzzer hide different types of errors. So make
 sure that each type of failure is unique (for an example, see the rlp fuzzer, where a counter `i` is used to differentiate between failures: 


### PR DESCRIPTION
1. **CONTRIBUTING.md**: 
   - `reproducitibility` -> `reproducibility`

2. **accounts/wallet/README.md**: 
   - `FOILLOWING ` -> `FOLLOWING `

3. **cmd/clif/rules.md**: 
   - `writeable` -> `writable`

4. **cmd/evm/README.md**: 
   - `behaviour` -> `behavior`
   - `blockshashes` -> `blockhashes `

5. **cmd/faucet/README.md**: 
   - `contain` -> `containing`

6. **tests/fuzzers/README.md**: 
   - `suppressions -folder` -> `suppressions folder` (hyphen removed)
