### PR TITLE
fix: typos in documentation files

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -20,7 +20,7 @@ cp ./build/bin/geth ./build/bin/bootnode /usr/local/bin/
 ```
 
 # Building on Windows
-It is possible to build and run Quorum on Windows. Below are the steps required, please use Slack for any questions or support. Keep in mind that original Go-Ethereum provides a number of helper scripts for environment configuration and build execution. We're not planning ot provide this ourselves, but steps below explain what you may need to set up on your system to create such scripts.
+It is possible to build and run Quorum on Windows. Below are the steps required, please use Slack for any questions or support. Keep in mind that original Go-Ethereum provides a number of helper scripts for environment configuration and build execution. We're not planning to provide this ourselves, but steps below explain what you may need to set up on your system to create such scripts.
 
 1. Install Go version 1.10 or 1.11 for Windows
 2. Create a folder that you will bind to be GOPATH

--- a/cmd/clef/tutorial.md
+++ b/cmd/clef/tutorial.md
@@ -227,7 +227,7 @@ In this example:
     - Auto-rejected if the message does not contain `bazonk`,
 - Any other requests will be passed along for manual confirmation.
 
-*Note, to make this example work, please use you own accounts. You can create a new account either via Clef or the traditional account CLI tools. If the latter was chosen, make sure both Clef and Geth use the same keystore by specifying `--keystore path/to/your/keystore` when running Clef.*
+*Note, to make this example work, please use your own accounts. You can create a new account either via Clef or the traditional account CLI tools. If the latter was chosen, make sure both Clef and Geth use the same keystore by specifying `--keystore path/to/your/keystore` when running Clef.*
 
 Attest the new rule file so that Clef will accept loading it:
 

--- a/cmd/evm/testdata/2/readme.md
+++ b/cmd/evm/testdata/2/readme.md
@@ -1,1 +1,1 @@
-These files examplify a selfdestruct to the `0`-address. 
+These files exemplify a selfdestruct to the `0`-address. 

--- a/cmd/evm/testdata/3/readme.md
+++ b/cmd/evm/testdata/3/readme.md
@@ -1,2 +1,2 @@
-These files examplify a transition where a transaction (excuted on block 5) requests
-the blockhash for block `1`. 
+These files exemplify a transition where a transaction (executed on block 5) requests
+the block hash for block `1`. 

--- a/cmd/evm/testdata/4/readme.md
+++ b/cmd/evm/testdata/4/readme.md
@@ -1,3 +1,3 @@
-These files examplify a transition where a transaction (excuted on block 5) requests
+These files exemplify a transition where a transaction (executed on block 5) requests
 the blockhash for block `4`, but where the hash for that block is missing. 
-It's expected that executing these should cause `exit` with errorcode `4`.
+It's expected that executing these should cause `exit` with error code `4`.

--- a/cmd/evm/testdata/5/readme.md
+++ b/cmd/evm/testdata/5/readme.md
@@ -1,1 +1,1 @@
-These files examplify a transition where there are no transcations, two ommers, at block `N-1` (delta 1) and `N-2` (delta 2).
+These files exemplify a transition where there are no transactions, two ommers, at block `N-1` (delta 1) and `N-2` (delta 2).

--- a/cmd/evm/testdata/8/readme.md
+++ b/cmd/evm/testdata/8/readme.md
@@ -33,7 +33,7 @@ dir=./testdata/8 && ./evm t8n --state.fork=Berlin --input.alloc=$dir/alloc.json 
 
 ```
 
-Simlarly, we can provide the input transactions via `stdin` instead of as file: 
+Similarly, we can provide the input transactions via `stdin` instead of as file: 
 
 ```
 dir=./testdata/8 \

--- a/swarm/README.md
+++ b/swarm/README.md
@@ -2,6 +2,6 @@
 
 https://swarm.ethereum.org
 
-Swarm is a distributed storage platform and content distribution service, a native base layer service of the ethereum web3 stack. The primary objective of Swarm is to provide a decentralized and redundant store for dapp code and data as well as block chain and state data. Swarm is also set out to provide various base layer services for web3, including node-to-node messaging, media streaming, decentralised database services and scalable state-channel infrastructure for decentralised service economies.
+Swarm is a distributed storage platform and content distribution service, a native base layer service of the ethereum web3 stack. The primary objective of Swarm is to provide a decentralized and redundant store for dapp code and data as well as block chain and state data. Swarm is also set out to provide various base layer services for web3, including node-to-node messaging, media streaming, decentralized database services and scalable state-channel infrastructure for decentralized service economies.
 
 **Note**: The codebase has been moved to [ethersphere/swarm](https://github.com/ethersphere/swarm)


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "planning ot provide" to "planning to provide".
Corrected "please use you own" to "please use your own".
Corrected "examplify" to "exemplify".
Corrected "excuted" to "executed".
Corrected "transcations" to "transactions".
Corrected "Simlarly" to "Similarly".
Corrected "decentralised" to "decentralized".

Please review the changes and let me know if any additional changes are needed.